### PR TITLE
Implement separate fan control

### DIFF
--- a/esphome/components/prana_ble/fan/__init__.py
+++ b/esphome/components/prana_ble/fan/__init__.py
@@ -5,10 +5,13 @@ import esphome.config_validation as cv
 from esphome.components import fan
 from esphome.const import (
     CONF_ID,
+    CONF_NAME
 )
 from .. import (
     PRANA_BLE_CLIENT_SCHEMA,
+    CONF_PRANA_ID,
     prana_ble_ns,
+    PranaBLEHub,
     register_prana_child,
 )
 
@@ -17,18 +20,24 @@ CODEOWNERS = ["@voed"]
 DEPENDENCIES = ["prana_ble"]
 
 PranaBLEFan = prana_ble_ns.class_("PranaBLEFan", fan.Fan, cg.PollingComponent)
+PranaFan = prana_ble_ns.enum("PranaFan")
+
+PRANA_FAN_TYPE = {
+    "INLET": PranaFan.FAN_IN,
+    "OUTLET": PranaFan.FAN_OUT,
+    "BOTH": PranaFan.FAN_BOTH
+}
 
 
-CONF_FANS = "fans"
-CONF_FAN_IN = "inlet_fan"
-CONF_FAN_OUT = "outlet_fan"
 CONF_HAS_AUTO = "has_auto"
-
+CONF_FAN_TYPE = "fan_type"
 CONFIG_SCHEMA = (
+
     fan.FAN_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(PranaBLEFan),
-            cv.Optional(CONF_HAS_AUTO, default=False) : cv.boolean
+            cv.Optional(CONF_HAS_AUTO) : cv.boolean,
+            cv.Required(CONF_FAN_TYPE) : cv.enum(PRANA_FAN_TYPE, upper=True)
         }
     )
     .extend(cv.polling_component_schema("1s"))
@@ -38,9 +47,9 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
+    f = await fan.register_fan(var, config)
     await cg.register_component(var, config)
-    await fan.register_fan(var, config)
+    cg.add(var.set_has_auto(config[CONF_HAS_AUTO]))
+    cg.add(var.set_fan_type(config[CONF_FAN_TYPE]))
     await register_prana_child(var, config)
 
-    if CONF_HAS_AUTO in config:
-        cg.add(var.set_has_auto(config[CONF_HAS_AUTO]))

--- a/esphome/components/prana_ble/fan/prana_ble_fan.cpp
+++ b/esphome/components/prana_ble/fan/prana_ble_fan.cpp
@@ -36,15 +36,22 @@ void PranaBLEFan::control(const fan::FanCall &call) {
     ESP_LOGW(TAG, "Not connected, cannot handle control call yet.");
     return;
   }
-  bool did_change = false;
-  auto call_state = call.get_state();
-  if(call_state.has_value() && call_state != this->state)
+  auto fans_locked = parent_->get_fans_locked();
+  if( (fans_locked && fan_type_ != PranaFan::FAN_BOTH) 
+      || (!fans_locked && fan_type_ == PranaFan::FAN_BOTH) )
   {
-    if(!call_state)
-      this->parent_->set_fan_off(PranaFan::FAN_BOTH);
+    ESP_LOGW(TAG, "Cannot control this fan. Check fan lock switch");
+    return;
+  }
+  bool did_change = false;
+  if(call.get_state().has_value() && *call.get_state() != this->state)
+  {
+    if(this->state)
+      this->parent_->set_fan_off(fan_type_);
     else
-      this->parent_->set_fan_on(PranaFan::FAN_BOTH);
-    delay(100);
+      this->parent_->set_fan_on(fan_type_);
+    this->state = !this->state;
+    return;
   }
   // ignore speed changes if not on or turning on
   if (this->state && call.get_speed().has_value()) {
@@ -52,18 +59,17 @@ void PranaBLEFan::control(const fan::FanCall &call) {
     if (speed > 0) {
       this->speed = speed;
       ESP_LOGW(TAG, "Setting fan speed %d", speed);
-      this->parent_->set_fan_speed(PranaFan::FAN_BOTH, speed);
+      this->parent_->set_fan_speed(fan_type_, speed);
 
       //this->parent_->set_fan_index(this->speed - 1);
       did_change = true;
     }
   }
-  auto preset = call.get_preset_mode();
-  if(!preset.empty() || this->preset_mode != preset)
+  if(!call.get_preset_mode().empty() || this->preset_mode != call.get_preset_mode())
   {
-    ESP_LOGD(TAG, "Changing preset from %s to %s", this->preset_mode.c_str(), preset.c_str());
-    auto mode = get_mode_from_string(preset);
-    this->preset_mode = preset;
+    ESP_LOGD(TAG, "Changing preset from %s to %s", this->preset_mode.c_str(), call.get_preset_mode().c_str());
+    auto mode = get_mode_from_string(call.get_preset_mode());
+    this->preset_mode = call.get_preset_mode();
     this->parent_->set_auto_mode(mode); 
     this->fan_mode = mode;
     did_change = true;
@@ -71,7 +77,6 @@ void PranaBLEFan::control(const fan::FanCall &call) {
   if (did_change) {
     this->publish_state();
   }
-
 }
 
 void PranaBLEFan::on_status(const PranaStatusPacket *data) {
@@ -79,11 +84,7 @@ void PranaBLEFan::on_status(const PranaStatusPacket *data) {
   bool did_change = false;
 
 
-  if (data->enabled != this->state) {
-    this->state = data->enabled;
-    did_change = true;
-  }
-  ESP_LOGD(TAG, "Changing to %s", this->preset_mode.c_str());
+
   if(this->fan_mode != data->fan_mode || this->preset_mode.empty())
   {
     this->preset_mode = PRANA_FAN_MODES[data->fan_mode];
@@ -92,12 +93,63 @@ void PranaBLEFan::on_status(const PranaStatusPacket *data) {
     did_change = true;
   }
 
-  auto data_speed = data->speed / 10;
-  // BedjetStatusPacket.fan_step is in range 0-19, but Fan.speed wants 1-20.
-  if (data_speed != this->speed) {
-    this->speed = data_speed;
-    did_change = true;
+
+  switch(fan_type_)
+  {
+    case PranaFan::FAN_IN:
+    {
+      auto data_speed = data->speed_in / 10;
+      // BedjetStatusPacket.fan_step is in range 0-19, but Fan.speed wants 1-20.
+      if (data_speed != this->speed) {
+        this->speed = data_speed;
+        did_change = true;
+      }
+      if (data->input_enabled != this->state) {
+        this->state = data->input_enabled;
+        did_change = true;
+      }
+      
+      ESP_LOGD(TAG, "Changing to %s", this->preset_mode.c_str());
+      break;
+    }
+    case PranaFan::FAN_OUT:
+    {
+      auto data_speed = data->speed_out / 10;
+      // BedjetStatusPacket.fan_step is in range 0-19, but Fan.speed wants 1-20.
+      if (data_speed != this->speed) {
+        this->speed = data_speed;
+        did_change = true;
+      }
+
+      if (data->output_enabled != this->state) {
+        this->state = data->output_enabled;
+        did_change = true;
+      }
+      
+      ESP_LOGD(TAG, "Changing to %s", this->preset_mode.c_str());
+      break;
+    }
+    case PranaFan::FAN_BOTH:
+    {
+      auto data_speed = data->speed / 10;
+      // BedjetStatusPacket.fan_step is in range 0-19, but Fan.speed wants 1-20.
+      if (data_speed != this->speed) {
+        this->speed = data_speed;
+        did_change = true;
+      }
+
+      if (data->enabled != this->state) {
+        this->state = data->enabled;
+        did_change = true;
+      }
+      
+      ESP_LOGD(TAG, "Changing to %s", this->preset_mode.c_str());
+
+        
+      break;
+    }
   }
+
 
   if (did_change) {
     this->publish_state();

--- a/esphome/components/prana_ble/fan/prana_ble_fan.cpp
+++ b/esphome/components/prana_ble/fan/prana_ble_fan.cpp
@@ -44,14 +44,14 @@ void PranaBLEFan::control(const fan::FanCall &call) {
     return;
   }
   bool did_change = false;
-  if(call.get_state().has_value() && *call.get_state() != this->state)
+  if(call.get_state().has_value() && call.get_state() != this->state)
   {
     if(this->state)
       this->parent_->set_fan_off(fan_type_);
     else
       this->parent_->set_fan_on(fan_type_);
     this->state = !this->state;
-    return;
+    did_change = true;
   }
   // ignore speed changes if not on or turning on
   if (this->state && call.get_speed().has_value()) {
@@ -80,10 +80,7 @@ void PranaBLEFan::control(const fan::FanCall &call) {
 }
 
 void PranaBLEFan::on_status(const PranaStatusPacket *data) {
-  ESP_LOGV(TAG, "[%s] Handling on_status with data=%p", this->get_name().c_str(), (void *) data);
   bool did_change = false;
-
-
 
   if(this->fan_mode != data->fan_mode || this->preset_mode.empty())
   {
@@ -109,7 +106,6 @@ void PranaBLEFan::on_status(const PranaStatusPacket *data) {
         did_change = true;
       }
       
-      ESP_LOGD(TAG, "Changing to %s", this->preset_mode.c_str());
       break;
     }
     case PranaFan::FAN_OUT:
@@ -126,7 +122,6 @@ void PranaBLEFan::on_status(const PranaStatusPacket *data) {
         did_change = true;
       }
       
-      ESP_LOGD(TAG, "Changing to %s", this->preset_mode.c_str());
       break;
     }
     case PranaFan::FAN_BOTH:
@@ -142,8 +137,6 @@ void PranaBLEFan::on_status(const PranaStatusPacket *data) {
         this->state = data->enabled;
         did_change = true;
       }
-      
-      ESP_LOGD(TAG, "Changing to %s", this->preset_mode.c_str());
 
         
       break;
@@ -183,7 +176,6 @@ void PranaBLEFan::update() {
   // TODO: if the hub component is already polling, do we also need to include polling?
   //  We're already going to get on_status() at the hub's polling interval.
   auto result = this->update_status_();
-  ESP_LOGD(TAG, "[%s] update_status result=%s", this->get_name().c_str(), result ? "true" : "false");
 }
 
 /** Resets states to defaults. */

--- a/esphome/components/prana_ble/fan/prana_ble_fan.h
+++ b/esphome/components/prana_ble/fan/prana_ble_fan.h
@@ -30,12 +30,12 @@ class PranaBLEFan : public fan::Fan, public PranaBLEClient, public PollingCompon
 
   void set_has_auto(bool has_auto) {has_auto_ = has_auto;}
 
-  //void set_fan_type(PranaFan fan) { fan_type = PranaFan::FAN_BOTH; }
+  void set_fan_type(PranaFan fan_type) { fan_type_ = fan_type; }
  protected:
   void control(const fan::FanCall &call) override;
   PranaFanMode fan_mode;
   fan::FanTraits traits_;
-  //PranaFan fan_type;
+  PranaFan fan_type_;
   bool has_auto_{false};
 
  private:

--- a/esphome/components/prana_ble/number/__init__.py
+++ b/esphome/components/prana_ble/number/__init__.py
@@ -1,0 +1,43 @@
+from esphome.components import number
+import esphome.config_validation as cv
+import esphome.codegen as cg
+from esphome.const import (
+    CONF_ID,
+)
+
+from .. import (
+    PRANA_BLE_CLIENT_SCHEMA,
+    prana_ble_ns,
+    register_prana_child,
+)
+
+DEPENDENCIES = ["prana_ble"]
+CODEOWNERS = ["@voed"]
+
+
+PranaBLENumber = prana_ble_ns.class_("PranaBLENumber", cg.PollingComponent)
+
+
+CONFIG_SCHEMA = cv.All(
+    number.number_schema(PranaBLENumber)
+    .extend(
+        {
+#            cv.GenerateID(): cv.use_id(PranaBLENumber),
+        }
+    )
+    .extend(cv.polling_component_schema("1min"))
+    .extend(PRANA_BLE_CLIENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await number.register_number(
+        var,
+        config,
+        min_value=1,
+        max_value=6,
+        step=1,
+    )
+    await register_prana_child(var, config)

--- a/esphome/components/prana_ble/number/prana_ble_number.cpp
+++ b/esphome/components/prana_ble/number/prana_ble_number.cpp
@@ -1,0 +1,42 @@
+#include "esphome/core/log.h"
+#include "prana_ble_number.h"
+
+namespace esphome {
+namespace prana_ble {
+
+
+void PranaBLENumber::setup() {
+}
+void PranaBLENumber::update() {
+}
+
+void PranaBLENumber::control(float value) {
+  ESP_LOGV(TAG, "Setting number: %f", value);
+  if (!this->parent_->is_connected()) {
+    ESP_LOGW(TAG, "Not connected, cannot handle control call yet.");
+    return;
+  }
+  short ival = round(value);
+  if(parent_->get_brightness() != ival)
+  {
+    ESP_LOGW(TAG, "Setting number: %f %i", value, ival);
+    parent_->set_brightness(ival);
+    this->publish_state(value);
+  }
+
+  
+}
+
+
+void PranaBLENumber::on_status(const PranaStatusPacket *data) {
+  if(data == nullptr)
+    return;
+
+  this->publish_state(parent_->get_brightness());
+}
+void PranaBLENumber::dump_config() {
+  LOG_NUMBER("", "PranaBLE Number", this);
+}
+std::string PranaBLENumber::describe() { return "Prana BLE Number"; }
+}  // namespace prana_ble
+}  // namespace esphome

--- a/esphome/components/prana_ble/number/prana_ble_number.h
+++ b/esphome/components/prana_ble/number/prana_ble_number.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "esphome/components/number/number.h"
+#include "esphome/core/component.h"
+#include "esphome/core/optional.h"
+#include "../prana_ble_child.h"
+#include "../prana_ble_const.h"
+
+namespace esphome {
+namespace prana_ble {
+
+class PranaBLENumber : public number::Number, public PranaBLEClient, public PollingComponent {
+ public:
+  void update() override;
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  /* PranaClient status update */
+  void on_status(const PranaStatusPacket *data) override;
+  void on_prana_state(bool is_ready) override{};
+  std::string describe() override;
+
+ protected:
+  void control(float value) override;
+  bool restore_value_{false};
+};
+
+}  // namespace prana_ble
+}  // namespace esphome

--- a/esphome/components/prana_ble/prana_ble_const.h
+++ b/esphome/components/prana_ble/prana_ble_const.h
@@ -67,7 +67,9 @@ enum PranaCommand : uint8_t {
 
 struct PranaStatusPacket {
   uint8_t magic[2];
-  uint8_t command[7];
+  uint8_t prefix[2];
+  uint32_t time;
+  uint8_t suffix;
   uint8_t unused1; // C0
   bool enabled : 8;//[10]
   uint8_t unused2;

--- a/esphome/components/prana_ble/prana_ble_const.h
+++ b/esphome/components/prana_ble/prana_ble_const.h
@@ -88,7 +88,7 @@ struct PranaStatusPacket {
   uint8_t unknown4[6];//35-40
   uint8_t unused9;
   bool winter_mode : 8;//42
-  uint8_t unknown5[6];//47
+  uint8_t unknown5[5];//47
   short temp_inside_in;//48-49
   uint8_t unknown6;
   short temp_outside_in;//51-52 //short?

--- a/esphome/components/prana_ble/prana_ble_hub.cpp
+++ b/esphome/components/prana_ble/prana_ble_hub.cpp
@@ -71,6 +71,21 @@ bool PranaBLEHub::command_disconnect()
 }
 
 
+void PranaBLEHub::set_fans_locked(bool locked)
+{
+  if(locked != fans_locked_)
+  {
+    
+    send_command(CMD_FAN_LOCK, false);
+    
+  }
+}
+
+bool PranaBLEHub::get_fans_locked()
+{
+  return fans_locked_;
+}
+
 bool PranaBLEHub::set_fan_speed(PranaFan fan, short new_speed)
 {
   auto speed_diff = new_speed - get_fan_speed(fan);
@@ -161,6 +176,7 @@ bool PranaBLEHub::set_fan_step(PranaFan fan, bool up)
 
 bool PranaBLEHub::set_fan_off(PranaFan fan)
 {
+  ESP_LOGD(TAG, "TURNING OFF FAN %i", fan);
   switch(fan)
   {
     case FAN_BOTH:
@@ -188,9 +204,9 @@ bool PranaBLEHub::set_fan_on(PranaFan fan)
         status.enabled = true;
       break;
     case FAN_IN:
-      return false;
+      return command_fan_in_off();
     case FAN_OUT:
-      return false;
+      return command_fan_out_off();
   }
   return false;
 }
@@ -421,6 +437,7 @@ void PranaBLEHub::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
           }
         } 
         this->last_notify_ = millis();
+        this->fans_locked_ = packet->fans_locked;
         ESP_LOGV(TAG, "Packet: %s", format_hex_pretty(param->notify.value, param->notify.value_len).c_str());
         ESP_LOGV(TAG, "speed: %d", param->notify.value[26] / 10);
         ESP_LOGV(TAG, "speed: %d", packet->speed / 10);

--- a/esphome/components/prana_ble/prana_ble_hub.cpp
+++ b/esphome/components/prana_ble/prana_ble_hub.cpp
@@ -227,6 +227,24 @@ short PranaBLEHub::get_fan_speed(PranaFan fan)
 }
 
 
+short PranaBLEHub::get_brightness()
+{
+  return log2(status.brightness) +1;
+}
+void PranaBLEHub::set_brightness(short value)
+{
+  if(value == get_brightness())
+    return;
+
+  auto diff = (value - get_brightness() + 6) % 6;
+  ESP_LOGW(TAG, "Sending brightness %i times %i %i", diff,value, get_brightness());
+  for(int i=0; i < diff; ++i) {
+    send_command(CMD_BRIGHTNESS, false);
+    delay(10);
+  }
+
+
+}
 bool PranaBLEHub::send_command(PranaCommand command, bool update) {
   auto packet = new PranaCmdPacket(command);
   auto status = this->send_packet(packet, update);

--- a/esphome/components/prana_ble/prana_ble_hub.h
+++ b/esphome/components/prana_ble/prana_ble_hub.h
@@ -57,7 +57,7 @@ class PranaBLEHub : public esphome::ble_client::BLEClientNode, public PollingCom
   void set_fans_locked(bool locked);
   bool get_fans_locked();
 
-  short get_fan_speed(PranaFan fan); 
+  short get_fan_speed(PranaFan fan);
   bool set_fan_speed(PranaFan fan, short new_speed);
 
   bool set_fan_off(PranaFan fan);
@@ -65,6 +65,9 @@ class PranaBLEHub : public esphome::ble_client::BLEClientNode, public PollingCom
   bool set_fan_on(PranaFan fan);
 
   bool set_auto_mode(PranaFanMode new_mode);
+
+  short get_brightness();
+  void set_brightness(short value);
 
   /** Send the `button`. */
   bool send_command(const PranaCommand command, bool update=false);

--- a/esphome/components/prana_ble/prana_ble_hub.h
+++ b/esphome/components/prana_ble/prana_ble_hub.h
@@ -54,6 +54,9 @@ class PranaBLEHub : public esphome::ble_client::BLEClientNode, public PollingCom
   bool command_fan_in_speed_down() { return send_command(CMD_FAN_IN_SPEED_DOWN, true); }
   bool command_fan_in_off() { return send_command(CMD_FAN_IN_OFF, true); }
 
+  void set_fans_locked(bool locked);
+  bool get_fans_locked();
+
   short get_fan_speed(PranaFan fan); 
   bool set_fan_speed(PranaFan fan, short new_speed);
 
@@ -114,6 +117,7 @@ class PranaBLEHub : public esphome::ble_client::BLEClientNode, public PollingCom
   static const uint32_t DEFAULT_STATUS_TIMEOUT = 900000;
 
   PranaStatusPacket status;
+  bool fans_locked_;
 
   uint8_t set_notify_(bool enable);
   /** Send the `PranaCmdPacket` to the device. */

--- a/esphome/components/prana_ble/sensor/__init__.py
+++ b/esphome/components/prana_ble/sensor/__init__.py
@@ -76,13 +76,13 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
-                accuracy_decimals=2,
+                accuracy_decimals=0,
                 device_class=DEVICE_CLASS_HUMIDITY,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_HECTOPASCAL,
-                accuracy_decimals=1,
+                accuracy_decimals=0,
                 device_class=DEVICE_CLASS_PRESSURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
@@ -95,6 +95,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_TVOC): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PARTS_PER_BILLION,
                 accuracy_decimals=0,
+                device_class=DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(

--- a/esphome/components/prana_ble/sensor/prana_ble_sensors.cpp
+++ b/esphome/components/prana_ble/sensor/prana_ble_sensors.cpp
@@ -26,7 +26,6 @@ float convert_temp(short temp)
 }
 
 void PranaBLESensors::on_status(const PranaStatusPacket *data) {
-  ESP_LOGV(TAG, " Handling on_status with data=%p",  (void *) data);
   if(data == nullptr)
     return;
   

--- a/esphome/components/prana_ble/switch/__init__.py
+++ b/esphome/components/prana_ble/switch/__init__.py
@@ -24,6 +24,7 @@ CONF_HEATING = "heating"
 CONF_WINTER_MODE = "winter_mode"
 CONF_AUTO_MODE = "auto_mode"
 CONF_CONNECT = "connect"
+CONF_FAN_LOCK = "fan_lock"
 
 
 CONFIG_SCHEMA = (
@@ -34,7 +35,8 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_ENABLE): switch.switch_schema(PranaBLESwitch),
             cv.Optional(CONF_HEATING): switch.switch_schema(PranaBLESwitch),
             cv.Optional(CONF_WINTER_MODE): switch.switch_schema(PranaBLESwitch),
-            cv.Optional(CONF_AUTO_MODE): switch.switch_schema(PranaBLESwitch)
+            cv.Optional(CONF_AUTO_MODE): switch.switch_schema(PranaBLESwitch),
+            cv.Optional(CONF_FAN_LOCK): switch.switch_schema(PranaBLESwitch)
         }
     )
     .extend(cv.polling_component_schema("1s"))
@@ -66,8 +68,9 @@ async def to_code(config):
         cg.add(sw.set_switch_type(PranaSwitchType.WINTER))
         await register_prana_child(sw, config)
 
-    if CONF_AUTO_MODE in config:
-        sw = await switch.new_switch(config[CONF_AUTO_MODE])
+
+    if CONF_FAN_LOCK in config:
+        sw = await switch.new_switch(config[CONF_FAN_LOCK])
         await cg.register_component(sw, config)
-        cg.add(sw.set_switch_type(PranaSwitchType.AUTO))
+        cg.add(sw.set_switch_type(PranaSwitchType.FAN_LOCK))
         await register_prana_child(sw, config)

--- a/esphome/components/prana_ble/switch/prana_ble_switch.cpp
+++ b/esphome/components/prana_ble/switch/prana_ble_switch.cpp
@@ -36,11 +36,6 @@ void PranaBLESwitch::write_state(bool state) {
       this->parent_->command_winter_mode();
       break;
     }
-    case PranaSwitchType::AUTO:
-    {
-      this->parent_->command_auto_mode();
-      break;
-    }
     case PranaSwitchType::CONNECT:
     {
       if(state)
@@ -49,7 +44,13 @@ void PranaBLESwitch::write_state(bool state) {
       }
       else
         this->parent_->command_disconnect();
-      
+      break;
+    }
+    case PranaSwitchType::FAN_LOCK:
+    {
+      parent_->set_fans_locked(state);
+
+      break;
     }
   }
 
@@ -78,14 +79,16 @@ void PranaBLESwitch::on_status(const PranaStatusPacket *data) {
       this->publish_state(data->winter_mode);
       break;
     }
-    case PranaSwitchType::AUTO:
-    {
-      //this->publish_state(data->auto_mode);
-      break;
-    }
     case PranaSwitchType::CONNECT:
     {
       this->publish_state(this->parent_->is_connection_enabled());
+      break;
+    }
+
+    case PranaSwitchType::FAN_LOCK:
+    {
+      this->publish_state(this->parent_->get_fans_locked());
+      break;
     }
   }
 }

--- a/esphome/components/prana_ble/switch/prana_ble_switch.cpp
+++ b/esphome/components/prana_ble/switch/prana_ble_switch.cpp
@@ -58,7 +58,6 @@ void PranaBLESwitch::write_state(bool state) {
 }
 
 void PranaBLESwitch::on_status(const PranaStatusPacket *data) {
-  ESP_LOGD(TAG, "[%s] Handling on_status with data=%p", this->get_name().c_str(), (void *) data);
     if(data == nullptr)
     return;
   switch(switch_type_)

--- a/esphome/components/prana_ble/switch/prana_ble_switch.h
+++ b/esphome/components/prana_ble/switch/prana_ble_switch.h
@@ -18,8 +18,8 @@ enum PranaSwitchType
   ENABLE,
   HEAT,
   WINTER,
-  AUTO,
-  CONNECT
+  CONNECT,
+  FAN_LOCK
 };
 
 class PranaBLESwitch : public switch_::Switch, public PranaBLEClient, public PollingComponent {

--- a/prana_conf_example.yaml
+++ b/prana_conf_example.yaml
@@ -1,13 +1,25 @@
-esphome:
+substitutions:
   name: prana
-  friendly_name: prana
-
-
+  device_description: "Monitor and control a Parana Recuperator via bluetooth"
+  external_components_source: github://voed/prana_ble@master
+  mac_address_01: 00:A0:50:00:00:00
+  mac_address_02: 00:A0:50:00:00:01
+   
+esphome:
+  friendly_name: Prana
+  name: ${name}
+  comment: ${device_description}
+  
 esp32:
   board: esp32dev
   framework: # Strongly recommended to use IDF framework instead of arduino. 
     type: esp-idf
 
+external_components:
+  - source: ${external_components_source}
+    components: [prana_ble] 
+    refresh: 0s
+    
 # Enable logging
 logger:
   level: DEBUG
@@ -30,52 +42,95 @@ wifi:
     ssid: "Prana Fallback Hotspot"
     password: !secret wifi_password
 
-captive_portal:
-
 # MAC address can be obtained via "BLE Scanner" app on your smartphone or BLE Client Tracker component
+
+# Enables scanning of Bluetooth (BLE) devices via ESP32. To determine the MAC address
+# esp32_ble_tracker:
+# text_sensor:
+#   - platform: ble_scanner
+#     name: "BLE Devices Scanner"
+    
 # TODO: try to merge it with "prana_ble"
 # TODO: make option to add by device name?
 ble_client:
-  - mac_address: 00:A0:50:00:00:03
+  - mac_address: ${mac_address_01}
     id: prana
+#You can use multiple devices by specifying their MACS and ids
+  - mac_address: ${mac_address_02}
+    id: prana2
 
 prana_ble:
-  id: prana_client
-  ble_client_id: prana
+  - id: prana_client
+    ble_client_id: prana
+  - id: prana_client2
+    ble_client_id: prana2
 
-# voltage and frequency sensors seems only available for old devices with 220V fans
 sensor:
   - platform: prana_ble
     prana_ble_id: prana_client
-    voltage:
-      name: "Prana voltage"
-    frequency:
-      name: "Prana frequency"
 
+#temperature sensors
+    temperature_inside_inlet: # top left sensor in Prana app
+      name: "Temperature inside inlet" 
+    temperature_inside_outlet: # bottom left sensor in Prana app
+      name: "Temperature inside outlet" 
+    temperature_outside_inlet:  # top right sensor in Prana app
+      name: "Temperature outside inlet"
+    temperature_outside_outlet: # bottom right sensor in Prana app
+      name: "Temperature outside outlet"
+
+    co2:
+      name: "CO2"
+    pressure:
+      name: "Pressure"
+    humidity:
+      name: "Humidity"
+    tvoc:
+      name: "TVOC"
+      
+# voltage and frequency sensors seems only available for old devices with 220V fans
+    voltage:
+      name: "Voltage"
+    frequency:
+      name: "Frequency"
+      
 switch:
   - platform: prana_ble
     prana_ble_id: prana_client
     connect: # Switch to turn off BLE connection between recuperator and ESP32. Useful if you want to connect from native smartphone app
-      name: prana_connect
+      name: Bluetooth connect
       restore_mode: ALWAYS_ON
     enable: # turn on/off the device
-      id: enable
-      name: prana_enable
+      name: Enable
     heating: # turn on/off internal heating element
-      id: heating
-      name: prana_heating
+      name: Heating
     winter_mode:  # turn on/off "winter" mode
-      name: prana_winter_mode
-    auto_mode:  # turn on/off "auto" mode. Untested.
-      name: prana_auto_mode
+      name: Winter mode
+    fan_lock:
+      name: Fan lock
 
-# TODO: make option to control in/out fans. For now only controlling both fans available.
+# TODO: make this more readable
 fan:
   - platform: prana_ble
     prana_ble_id: prana_client
-    name: prana_fan
+    has_auto: true #if your recuperator does not have auto/auto+ options, change this to false
+    name: In/Out fans # use fan_lock switch to control separate fans
+    fan_type: BOTH
 
-external_components:
-  - source: https://github.com/voed/prana_ble@main
-    components: [prana_ble]
-    refresh: 1min
+  - platform: prana_ble
+    prana_ble_id: prana_client
+    has_auto: true
+    name: Inlet fan
+    fan_type: INLET
+
+  - platform: prana_ble
+    prana_ble_id: prana_client
+    has_auto: true
+    name: Outlet fan
+    fan_type: OUTLET
+
+number:
+  - platform: prana_ble
+    prana_ble_id: prana_client
+    name: Display brightness
+


### PR DESCRIPTION
Now fans may be controlled separately by using fan_lock switch.

``` yaml
switch:
  - platform: prana_ble
    prana_ble_id: prana_client
    connect:
       name: prana_connect
       restore_mode: ALWAYS_ON
    enable:
       id: enable
       name: prana_enable
    heating:
      id: heating
      name: prana_heating
    winter_mode:
      name: prana_winter_mode
    fan_lock:
      name: prana_fan_lock
      

fan:
  - platform: prana_ble
    prana_ble_id: prana_client
    has_auto: true
    name: both_fans
    fan_type: BOTH

  - platform: prana_ble
    prana_ble_id: prana_client
    has_auto: true
    name: inlet_fan
    fan_type: INLET

  - platform: prana_ble
    prana_ble_id: prana_client
    has_auto: true
    name: outlet_fan
    fan_type: OUTLET
```

Closes #7 