### PR TITLE
fix compilation error with esphome 2025.9.0

### DIFF
--- a/esphome/components/prana_ble/prana_ble_hub.cpp
+++ b/esphome/components/prana_ble/prana_ble_hub.cpp
@@ -576,7 +576,7 @@ void PranaBLEHub::dump_config() {
   ESP_LOGCONFIG(TAG, "Prana BLE Hub '%s'", this->get_name().c_str());
   ESP_LOGCONFIG(TAG, "  ble_client.app_id: %d", this->parent()->app_id);
   ESP_LOGCONFIG(TAG, "  ble_client.conn_id: %d", this->parent()->get_conn_id());
-  LOG_UPDATE_INTERVAL(this)
+  LOG_UPDATE_INTERVAL(this);
   ESP_LOGCONFIG(TAG, "  Child components (%d):", this->children_.size());
   for (auto *child : this->children_) {
     ESP_LOGCONFIG(TAG, "    - %s", child->describe().c_str());


### PR DESCRIPTION
The compilation error:

```
In file included from src/esphome/core/component.h:8,
                 from src/esphome/core/automation.h:3,
                 from src/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h:3,
                 from src/esphome/components/esp32_ble_client/ble_client_base.h:5,
                 from src/esphome/components/ble_client/ble_client.h:3,
                 from src/esphome/components/prana_ble/prana_ble_hub.h:3,
                 from src/esphome/components/prana_ble/prana_ble_hub.cpp:1:
src/esphome/components/prana_ble/prana_ble_hub.cpp: In member function 'virtual void esphome::prana_ble::PranaBLEHub::dump_config()':
src/esphome/core/log.h:101:3: error: expected ';' before '::' token
  101 |   ::esphome::esp_log_printf_(ESPHOME_LOG_LEVEL_CONFIG, tag, __LINE__, ESPHOME_LOG_FORMAT(format), ##__VA_ARGS__)
      |   ^~
src/esphome/core/log.h:157:33: note: in expansion of macro 'esph_log_config'
  157 | #define ESP_LOGCONFIG(tag, ...) esph_log_config(tag, __VA_ARGS__)
      |                                 ^~~~~~~~~~~~~~~
src/esphome/components/prana_ble/prana_ble_hub.cpp:580:3: note: in expansion of macro 'ESP_LOGCONFIG'
  580 |   ESP_LOGCONFIG(TAG, "  Child components (%d):", this->children_.size());
      |   ^~~~~~~~~~~~~
```